### PR TITLE
Add option for backpressure on SinkOperation stream

### DIFF
--- a/mesos-rxjava-client/pom.xml
+++ b/mesos-rxjava-client/pom.xml
@@ -38,10 +38,6 @@
     </dependency>
     <dependency>
       <groupId>com.hubspot.mesos.rx.java</groupId>
-      <artifactId>mesos-rxjava-test</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.hubspot.mesos.rx.java</groupId>
       <artifactId>mesos-rxjava-util</artifactId>
     </dependency>
     <dependency>
@@ -79,6 +75,11 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.hubspot.mesos.rx.java</groupId>
+      <artifactId>mesos-rxjava-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/mesos-rxjava-client/src/main/java/com/hubspot/mesos/rx/java/MesosClientBuilder.java
+++ b/mesos-rxjava-client/src/main/java/com/hubspot/mesos/rx/java/MesosClientBuilder.java
@@ -46,9 +46,11 @@ public final class MesosClientBuilder<Send, Receive> {
     private Send subscribe;
     private Function<Observable<Receive>, Observable<Optional<SinkOperation<Send>>>> streamProcessor;
     private Observable.Transformer<byte[], byte[]> backpressureTransformer;
+    private Observable.Transformer<SinkOperation<Send>, SinkOperation<Send>> sendEventBackpressureTransformer;
 
     private MesosClientBuilder() {
         backpressureTransformer = observable -> observable;
+        sendEventBackpressureTransformer = observable -> observable;
     }
 
     /**
@@ -186,6 +188,21 @@ public final class MesosClientBuilder<Send, Receive> {
         return this;
     }
 
+    /**
+     * Instructs the SinkOperation<Send> stream to be composed with reactive pull backpressure such that
+     * a burst of outgoing Mesos messages is handled by an unbounded buffer rather than a
+     * MissingBackpressureException.
+     *
+     * @return this builder (allowing for further chained calls)
+     * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
+     */
+    @NotNull
+    public MesosClientBuilder<Send, Receive> onSendEventBackpressureBuffer(
+    ) {
+        this.sendEventBackpressureTransformer = observable -> observable.onBackpressureBuffer();
+        return this;
+    }
+
 
     /**
      * Instructs the HTTP byte[] stream to be composed with reactive pull backpressure such that
@@ -205,6 +222,24 @@ public final class MesosClientBuilder<Send, Receive> {
         final long capacity
     ) {
         this.backpressureTransformer = observable -> observable.onBackpressureBuffer(capacity);
+        return this;
+    }
+
+    /**
+     * Instructs the SinkOperation<Send> stream to be composed with reactive pull backpressure such that
+     * a burst of outgoing Mesos messages is handled by a bounded buffer rather than a
+     * MissingBackpressureException. If the buffer is overflown, a {@link java.nio.BufferOverflowException}
+     * is thrown.
+     *
+     * @param capacity number of slots available in the buffer.
+     * @return this builder (allowing for further chained calls)
+     * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
+     */
+    @NotNull
+    public MesosClientBuilder<Send, Receive> onSendEventBackpressureBuffer(
+        final long capacity
+    ) {
+        this.sendEventBackpressureTransformer = observable -> observable.onBackpressureBuffer(capacity);
         return this;
     }
 
@@ -246,6 +281,40 @@ public final class MesosClientBuilder<Send, Receive> {
     }
 
     /**
+     * Instructs the SinkOperation<Send> stream to be composed with reactive pull backpressure such that
+     * a burst of outgoing Mesos messages is handled by a bounded buffer rather than a
+     * MissingBackpressureException. If the buffer is overflown, your own custom onOverflow callback
+     * will be invoked, and the overflow will mitigate the issue based on the {@link BackpressureOverflow.Strategy}
+     * that you select.
+     *
+     * <ul>
+     *     <li>{@link BackpressureOverflow#ON_OVERFLOW_ERROR} (default) will {@code onError} dropping all undelivered items,
+     *     unsubscribing from the source, and notifying the producer with {@code onOverflow}. </li>
+     *     <li>{@link BackpressureOverflow#ON_OVERFLOW_DROP_LATEST} will drop any new items emitted by the producer while
+     *     the buffer is full, without generating any {@code onError}.  Each drop will however invoke {@code onOverflow}
+     *     to signal the overflow to the producer.</li>
+     *     <li>{@link BackpressureOverflow#ON_OVERFLOW_DROP_OLDEST} will drop the oldest items in the buffer in order to make
+     *     room for newly emitted ones. Overflow will not generate an{@code onError}, but each drop will invoke
+     *     {@code onOverflow} to signal the overflow to the producer.</li>
+     * </ul>
+     *
+     * @param capacity number of slots available in the buffer.
+     * @param onOverflow action to execute if an item needs to be buffered, but there are no available slots.  Null is allowed.
+     * @param strategy how should the {@code Observable} react to buffer overflows.
+     * @return this builder (allowing for further chained calls)
+     * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
+     */
+    @NotNull
+    public MesosClientBuilder<Send, Receive> onSendEventBackpressureBuffer(
+        final long capacity,
+        @Nullable final Action0 onOverflow,
+        @NotNull final BackpressureOverflow.Strategy strategy
+    ) {
+        this.backpressureTransformer = observable -> observable.onBackpressureBuffer(capacity, onOverflow, strategy);
+        return this;
+    }
+
+    /**
      * Builds the instance of {@link MesosClient} that has been configured by this builder.
      * All items are expected to have non-null values, if any item is null an exception will be thrown.
      * @return The configured {@link MesosClient}
@@ -259,7 +328,8 @@ public final class MesosClientBuilder<Send, Receive> {
             checkNotNull(receiveCodec),
             checkNotNull(subscribe),
             checkNotNull(streamProcessor),
-            checkNotNull(backpressureTransformer)
+            checkNotNull(backpressureTransformer),
+            checkNotNull(sendEventBackpressureTransformer)
         );
     }
 

--- a/mesos-rxjava-example/mesos-rxjava-example-framework/pom.xml
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/pom.xml
@@ -47,10 +47,6 @@
     </dependency>
     <dependency>
       <groupId>com.hubspot.mesos.rx.java</groupId>
-      <artifactId>mesos-rxjava-test</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.hubspot.mesos.rx.java</groupId>
       <artifactId>mesos-rxjava-util</artifactId>
     </dependency>
     <dependency>
@@ -71,6 +67,11 @@
     </dependency>
 
     <!-- Test -->
+    <dependency>
+      <groupId>com.hubspot.mesos.rx.java</groupId>
+      <artifactId>mesos-rxjava-test</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>


### PR DESCRIPTION
For a large burst of acks back to mesos, we can occasionally get a MissingBackpressureException here. Add an option to buffer those cases